### PR TITLE
Update release workflow for publishing to marketplace

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,6 +171,24 @@ jobs:
         run: |
           mv ./artifacts/vscode-extension-linux/*.vsix ./artifacts/konveyor-${{ needs.test_the_release.outputs.tag_name }}.vsix
 
+      - name: Set up Node.js for publishing
+        if: ${{ github.event.inputs.prerelease == 'false' && github.event.inputs.dry-run == 'false' && github.repository_owner == 'hhpatel14' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Publish to VS Code Marketplace
+        if: ${{ github.event.inputs.prerelease == 'false' && github.event.inputs.dry-run == 'false' && github.repository_owner == 'hhpatel14' }}
+        run: |
+          echo "TEST MODE: Would publish ./artifacts/konveyor-${{ needs.test_the_release.outputs.tag_name }}.vsix"
+          echo "File path: ./artifacts/konveyor-${{ needs.test_the_release.outputs.tag_name }}.vsix"
+          echo "Tag name: ${{ needs.test_the_release.outputs.tag_name }}"
+          echo "Repository owner: ${{ github.repository_owner }}"
+          echo "Event name: ${{ github.event_name }}"
+          echo "Prerelease: ${{ github.event.inputs.prerelease }}"
+          echo "Dry run: ${{ github.event.inputs.dry-run }}"
+          # npx vsce publish --packagePath ./artifacts/konveyor-${{ needs.test_the_release.outputs.tag_name }}.vsix --pat ${{ secrets.VSCODE_MARKETPLACE_TOKEN }}
+
       - name: Create Release
         if: ${{ github.event.inputs.dry-run == 'false' }}
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
