### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ on:
       - "*"
   release:
     types:
-      - prereleased
       - published
 
   workflow_dispatch:
@@ -204,13 +203,13 @@ jobs:
           mv ./artifacts/vscode-extension-linux/*.vsix ./artifacts/konveyor-${{ needs.test_the_release.outputs.tag_name }}.vsix
 
       - name: Set up Node.js for publishing
-        if: ${{ github.event.inputs.dry-run == 'false' && github.repository_owner == 'hhpatel14' && github.event_name == 'release' }}
+        if: ${{ github.repository_owner == 'hhpatel14' && github.event_name == 'release' }}
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
 
       - name: Publish to VS Code Marketplace (release)
-        if: ${{ needs.test_the_release.outputs.prerelease == 'false' && github.event.inputs.dry-run == 'false' && github.repository_owner == 'hhpatel14' && github.event_name == 'release' }}
+        if: ${{ needs.test_the_release.outputs.prerelease == 'false' && github.repository_owner == 'hhpatel14' && github.event_name == 'release' }}
         run: |
           echo "Publishing ./artifacts/konveyor-${{ needs.test_the_release.outputs.tag_name }}.vsix"
           echo "File path: ./artifacts/konveyor-${{ needs.test_the_release.outputs.tag_name }}.vsix"
@@ -222,7 +221,7 @@ jobs:
           npx vsce publish --packagePath ./artifacts/konveyor-${{ needs.test_the_release.outputs.tag_name }}.vsix --pat ${{ secrets.VSCODE_MARKETPLACE_TOKEN }}
 
       - name: Publish to VS Code Marketplace (pre-release)
-        if: ${{ needs.test_the_release.outputs.prerelease == 'true' && github.event.inputs.dry-run == 'false' && github.repository_owner == 'hhpatel14' && github.event_name == 'release' }}
+        if: ${{ needs.test_the_release.outputs.prerelease == 'true' && github.repository_owner == 'hhpatel14' && github.event_name == 'release' }}
         run: |
           echo "Publishing (pre-release) ./artifacts/konveyor-${{ needs.test_the_release.outputs.tag_name }}.vsix"
           echo "Tag name: ${{ needs.test_the_release.outputs.tag_name }}"


### PR DESCRIPTION
<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
