### PR TITLE
version change for pre-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,17 +141,17 @@ jobs:
           npm run build
           npm run collect-assets -- --use-release
           npm run dist
-      
+
       - name: Package VSIX (pre-release)
         if: ${{ needs.test_the_release.outputs.prerelease == 'true' }}
         run: |
-          npx @vscode/vsce package --pre-release --no-dependencies -o ./dist/konveyor-${{ needs.test_the_release.outputs.tag_name }}.vsix
+          npm run package -- --pre-release
 
       - name: Package VSIX (release)
         if: ${{ needs.test_the_release.outputs.prerelease == 'false' }}
         run: |
-          npm run package --pre-release
-          
+          npm run package
+
       - name: Upload VSIX artifact
         uses: actions/upload-artifact@v4
         with:
@@ -210,7 +210,7 @@ jobs:
       - name: Rename VSIX Packages
         run: |
           mv ./artifacts/vscode-extension-linux/*.vsix ./artifacts/konveyor-${{ needs.test_the_release.outputs.tag_name }}.vsix
-          
+
       - name: Debug release context
         if: ${{ github.event_name == 'release' }}
         run: |


### PR DESCRIPTION
<!--
## PR Title Prefix

Every **PR Title** should be prefixed with :text: to indicate its type.

- Breaking change: :warning: (`:warning:`)
- Non-breaking feature: :sparkles: (`:sparkles:`)
- Patch fix: :bug: (`:bug:`)
- Docs: :book: (`:book:`)
- Infra/Tests/Other: :seedling: (`:seedling:`)
- No release note: :ghost: (`:ghost:`)

For example, a pull request containing breaking changes might look like
`:warning: My pull request contains breaking changes`.

Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include
the emoji directly in the PR title -- **please use the alias**. It used to be
the case that projects using emojis for PR typing had to include the emoji
directly because GitHub didn't render the alias. Given that `:warning:` is
easy enough to read as text, easy to parse in release tooling, and rendered in
GitHub well, we prefer to standardize on the alias.

For more information, please see the Konveyor
[Versioning Doc](https://github.com/konveyor/release-tools/blob/main/VERSIONING.md).
-->
